### PR TITLE
feat(fleet): add CARETAKER_FLEET_SECRET for signed heartbeats

### DIFF
--- a/.github/workflows/maintainer.yml
+++ b/.github/workflows/maintainer.yml
@@ -122,6 +122,7 @@ jobs:
           CARETAKER_EVENT_PAYLOAD: ${{ toJSON(github.event) }}
           CARETAKER_RUN_MODE: ${{ github.event.inputs.mode || 'full' }}
           CARETAKER_EVENT_TYPE: ${{ github.event_name }}
+          CARETAKER_FLEET_SECRET: ${{ secrets.CARETAKER_FLEET_SECRET }}
         run: |
           caretaker run \
             --config .github/maintainer/config.yml \
@@ -166,6 +167,7 @@ jobs:
           COPILOT_PAT: ${{ secrets.COPILOT_PAT }}
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           CARETAKER_FAILED_RUN_ID: ${{ github.run_id }}
+          CARETAKER_FLEET_SECRET: ${{ secrets.CARETAKER_FLEET_SECRET }}
           CARETAKER_EVENT_PAYLOAD: >-
             {
               "workflow_run": {


### PR DESCRIPTION
## Fleet Registry Opt-in

This PR adds `CARETAKER_FLEET_SECRET` to the caretaker workflow environment so signed heartbeats can be sent to the central admin dashboard.

### What changes
- `.github/workflows/maintainer.yml`: adds `CARETAKER_FLEET_SECRET` to the `Run` and `Self-heal` step env blocks

### What you need to do
1. **Add the secret**: Go to this repo's Settings → Secrets and variables → Actions → New repository secret, name it `CARETAKER_FLEET_SECRET`. Get the value from the caretaker admin.
2. **Merge this PR**: Once the secret is set and the next workflow run completes, a heartbeat will appear at https://caretaker.cat-herding.net/fleet.

> `fleet_registry.enabled: true` is already set in your config.yml — this PR just wires in the signing secret for secure heartbeats.

Part of caretaker v0.19.6 fleet registry opt-in.
